### PR TITLE
Add basic widget refresh functionality.

### DIFF
--- a/public/js/core.js
+++ b/public/js/core.js
@@ -1,30 +1,48 @@
-$('section').each(function(index) {
-	load_widget(this);
-});
+$(document).ready(function() {
 
-function load_widget(widget){
-	$(widget).html('<div class="loading"><img src="'+BASE_URL+'/themes/wood/ajax-loader-large.gif"></div>').fadeIn();
-
-	var data = $(widget).data();
-	var name = $(widget).attr("data-widget");
-
-	// This is nasty but couldn't think
-	// of a better way at this time.
-	var a = [];
-	for (key in data) {
-		a.push(key+"="+data[key]);
-	}
-	a.push("size="+$(widget).attr('class'));
-	var serialized = a.join("&");
-
-	$.ajax({
-		data: serialized,
-		dataType: "html",
-		type: "POST",
-		url: SITE_URL+name+"?"+new Date().getTime(),
-		success: function(data) {
-			$(widget).html(data).fadeIn();
-		}
+	$('section').each(function(index) {
+		init_widget(this);
 	});
-	return false;
-}
+
+	function init_widget(widget) {
+		var name = $(widget).attr("data-widget");
+		var data = $(widget).data();
+
+		// This is nasty but couldn't think
+		// of a better way at this time.
+		var a = [];
+		for (key in data) {
+			a.push(key+"="+data[key]);
+		}
+		a.push("size="+$(widget).attr('class'));
+		var serialized = a.join("&");
+
+		// Initial loading of widget
+		load_widget(widget, name, serialized);
+
+		// Set timer to refresh widget
+		var interval = $(widget).attr('data-interval');
+		if (interval) {
+			setInterval(function() {
+				load_widget(widget, name, serialized);
+			}, interval * 1000);
+		}
+
+		return false;
+	}
+
+	function load_widget(widget, name, data) {
+		$(widget).html('<div class="loading"><img src="'+BASE_URL+'/themes/wood/ajax-loader-large.gif"></div>').fadeIn();
+
+		$.ajax({
+			data: data,
+			dataType: "html",
+			type: "POST",
+			url: SITE_URL+name+"?"+new Date().getTime(),
+			success: function(data) {
+				$(widget).html(data).fadeIn();
+			}
+		});
+		return false;
+	}
+});


### PR DESCRIPTION
Some slight JavaScript refactoring and the addition of the ability to set widgets to refresh.

To get a widget to refresh, add a `data-interval` attribute to the widget containing the number of seconds the widget should wait before refreshing.  Example:

``` html
<section class="small" data-exchange="NASDAQ" data-symbol="GOOG" data-widget="stocks" data-interval="3600"></section>
```

A few areas of thought:
- What should happen if the widget refreshes before the AJAX request has responded?
- What if the user provides a non-integer in the data-interval attribute?  It seems to refresh very quickly - maybe add some primitive validation.
- Will widget data change during run time?  Should the attributes be serialized once or serialized it each time the widget refreshes?
