### PR TITLE
Fixed: pingdom time calculations and views

### DIFF
--- a/bundles/pingdom/libraries/Pingdom.php
+++ b/bundles/pingdom/libraries/Pingdom.php
@@ -72,6 +72,10 @@ class Pingdom {
 		if (is_array($results)) {
 			$totalresults = count($results);
 			for ($x=0; $x < $totalresults; $x++) {
+                // default to check creation time if no downtime has occured
+                if (!isset($results[$x]->lasterrortime)) {
+                   $results[$x]->lasterrortime = $results[$x]->created;
+                }
 				$lasterrortime = $this->elapsedTime($results[$x]->lasterrortime);
 				$results[$x]->lasterrortime_pretty = $this->elapsedTimeString($lasterrortime);
 

--- a/bundles/pingdom/views/large.php
+++ b/bundles/pingdom/views/large.php
@@ -11,7 +11,7 @@
 		<li class="clearfix">
 			<div class="msg <?php echo $item->status;?>">
 				<a href="http://<?php echo $item->hostname;?>" title="<?php echo $item->name;?>"><?php echo $item->hostname;?></a>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last downtime</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasterrortime_pretty;?></div>
@@ -21,7 +21,7 @@
 						<div class="t-size-x18 t-main"><?php echo $item->lastresponsetime;?>ms</div>
 					</div>
 				</div>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last test</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasttesttime_pretty;?></div>

--- a/bundles/pingdom/views/medium.php
+++ b/bundles/pingdom/views/medium.php
@@ -11,7 +11,7 @@
 		<li class="clearfix">
 			<div class="msg <?php echo $item->status;?>">
 				<a href="http://<?php echo $item->hostname;?>" title="<?php echo $item->name;?>"><?php echo $item->hostname;?></a>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last downtime</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasterrortime_pretty;?></div>
@@ -21,7 +21,7 @@
 						<div class="t-size-x18 t-main"><?php echo $item->lastresponsetime;?>ms</div>
 					</div>
 				</div>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last test</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasttesttime_pretty;?></div>

--- a/bundles/pingdom/views/small.php
+++ b/bundles/pingdom/views/small.php
@@ -11,7 +11,7 @@
 		<li class="clearfix">
 			<div class="msg <?php echo $item->status;?>">
 				<a href="http://<?php echo $item->hostname;?>" title="<?php echo $item->name;?>"><?php echo $item->hostname;?></a>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last downtime</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasterrortime_pretty;?></div>
@@ -21,7 +21,7 @@
 						<div class="t-size-x18 t-main"><?php echo $item->lastresponsetime;?>ms</div>
 					</div>
 				</div>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last test</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasttesttime_pretty;?></div>

--- a/bundles/pingdom/views/tiny.php
+++ b/bundles/pingdom/views/tiny.php
@@ -11,7 +11,7 @@
 		<li class="clearfix">
 			<div class="msg <?php echo $item->status;?>">
 				<a href="http://<?php echo $item->hostname;?>" title="<?php echo $item->name;?>"><?php echo $item->hostname;?></a>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last downtime</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasterrortime_pretty;?></div>
@@ -21,7 +21,7 @@
 						<div class="t-size-x18 t-main"><?php echo $item->lastresponsetime;?>ms</div>
 					</div>
 				</div>
-				<div class="b-server-time clrfix">
+				<div class="b-server-time clearfix">
 					<div class="b-server-downtime">
 						<div class="t-size-x11 t-small">Last test</div>
 						<div class="t-size-x18 t-main"><?php echo $item->lasttesttime_pretty;?></div>


### PR DESCRIPTION
Pingdom `lasterrortime` assumed that an error exists, but if one has not occurred since creation, the calculation is messed up, so now defaults to creation time.

`clrfix` class should be `clearfix` in views to match CSS 
